### PR TITLE
Us1

### DIFF
--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::ForecastController < ApplicationController
+  def index
+    render json: ForecastSerializer.new(ForecastService.get_forecast(params[:location])).serialize_forecast
+  end
+end

--- a/app/serializers/forecast_serializer.rb
+++ b/app/serializers/forecast_serializer.rb
@@ -1,0 +1,45 @@
+class ForecastSerializer
+  def initialize(data)
+    @data = data
+  end
+
+  def serialize_forecast
+    {
+      data: {
+        id: nil,
+        type: 'forecast',
+        attributes: {
+          current_weather: {
+            last_updated: @data[:current][:last_updated],
+            temperature: @data[:current][:temp_f],
+            feels_like: @data[:current][:feelslike_f],
+            humidity: @data[:current][:humidity],
+            uvi: @data[:current][:uv],
+            visbility: @data[:current][:vis_miles],
+            condition: @data[:current][:condition][:text],
+            icon: @data[:current][:condition][:icon]
+            },
+          daily_weather: @data[:forecast][:forecastday].map do |day|
+            {
+              date: day[:date],
+              sunrise: day[:astro][:sunrise],
+              sunset: day[:astro][:sunset],
+              max_temp: day[:day][:maxtemp_f],
+              min_temp: day[:day][:mintemp_f],
+              condition: day[:day][:condition][:text],
+              icon: day[:day][:condition][:icon]
+            }
+          end,
+          hourly_weather: @data[:forecast][:forecastday][0][:hour].map do |hour|
+            {
+              time: hour[:time][-5..-1],
+              temperature: hour[:temp_f],
+              condition: hour[:condition][:text],
+              icon: hour[:condition][:icon]
+            }
+          end
+          }
+          }
+        }
+  end
+end

--- a/app/services/forecast_service.rb
+++ b/app/services/forecast_service.rb
@@ -1,0 +1,18 @@
+class ForecastService
+  
+  def self.get_url(url)
+    response = Faraday.get(url)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def self.get_lat_long(location)
+    response = get_url("https://www.mapquestapi.com/geocoding/v1/address?key=#{ENV['MAPQUEST_API_KEY']}&location=#{location}")
+    latlong = response[:results][0][:locations][0][:latLng]
+    latlong.values.join(',')
+  end
+
+  def self.get_forecast(location)
+    latlong = ForecastService.get_lat_long(location)
+    forecast = get_url("http://api.weatherapi.com/v1/forecast.json?key=#{ENV['WEATHER_API_KEY']}&q=#{latlong}&days=5")
+  end
+end

--- a/spec/requests/retrieve_weather_for_a_city_spec.rb
+++ b/spec/requests/retrieve_weather_for_a_city_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe "GET /forecast" do
+  describe "happy path" do
+    it "can retrieve weather for a city" do
+
+      get "/api/v1/forecast?location=cincinatti,oh"
+
+      body = JSON.parse(response.body, symbolize_names: true)[:data][:attributes]
+
+      current = body[:current_weather]
+      daily = body[:daily_weather]
+      hourly = body[:hourly_weather]
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+      expect(response).to have_key(:data)
+      expect(response[:data]).to have_key(:id)
+      expect(response[:data]).to have_key(:type)
+      expect(response[:data][:id]).to eq(nil)
+      expect(response[:data][:type]).to eq("forecast")
+      expect(response[:data]).to have_key(:attributes)
+
+      expect(body).to have_key(:current_weather)
+      expect(body).to have_key(:daily_weather)
+      expect(body).to have_key(:hourly_weather)
+
+      expect(current).to have_key(:last_updated)
+      expect(current).to have_key(:temperature)
+      expect(current).to have_key(:feels_like)
+      expect(current).to have_key(:humidity)
+      expect(current).to have_key(:uvi)
+      expect(current).to have_key(:visibility)
+      expect(current).to have_key(:condition)
+
+      expect(daily).to have_key(:date)
+      expect(daily).to have_key(:sunrise)
+      expect(daily).to have_key(:sunset)
+      expect(daily).to have_key(:max_temp)
+      expect(daily).to have_key(:min_temp)
+      expect(daily).to have_key(:condition)
+      expect(hourly).to have_key(:time)
+      expect(hourly).to have_key(:temperature)
+      expect(hourly).to have_key(:conditions)
+    end
+  end
+end

--- a/spec/serializers/forecast_serializer_spec.rb
+++ b/spec/serializers/forecast_serializer_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe ForecastSerializer do
+  describe 'instance methods' do
+    it 'properly serializes forecast data' do
+      serialized = ForecastSerializer.new(ForecastService.get_forecast('Cincinatti, OH')).serialize_forecast
+      current = serialized[:data][:attributes][:current_weather]
+      daily = serialized[:data][:attributes][:daily_weather]
+      hourly = serialized[:data][:attributes][:hourly_weather]
+      
+      expect(serialized).to be_a(Hash)
+      expect(serialized[:data]).to be_a(Hash)
+      expect(serialized[:data][:id]).to eq(nil)
+      expect(serialized[:data][:type]).to eq('forecast')
+      expect(serialized[:data][:attributes]).to be_a(Hash)
+
+      expect(current).to be_a(Hash)
+      expect(current[:last_updated]).to be_a(String)
+      expect(current[:temperature]).to be_a(Float)
+      expect(current[:feels_like]).to be_a(Float)
+      expect(current[:humidity]).to be_a(Integer)
+      expect(current[:uvi]).to be_a(Float)
+      expect(current).to_not have_key(:temp_c)
+      expect(current).to_not have_key(:feelslike_c)
+      expect(current).to_not have_key(:vis_km)
+      expect(current).to_not have_key(:wind_kph)
+      expect(current).to_not have_key(:wind_dir)
+      expect(current).to_not have_key(:wind_degree)
+      expect(current).to_not have_key(:pressure_mb)
+      expect(current).to_not have_key(:pressure_in)
+      expect(current).to_not have_key(:precip_mm)
+      expect(current).to_not have_key(:precip_in)
+
+      expect(daily).to be_a(Array)
+      expect(daily[0]).to be_a(Hash)
+      expect(daily[0][:date]).to be_a(String)
+      expect(daily[0][:sunrise]).to be_a(String)
+      expect(daily[0][:sunset]).to be_a(String)
+      expect(daily[0][:max_temp]).to be_a(Float)
+      expect(daily[0][:min_temp]).to be_a(Float)
+      expect(daily[0][:condition]).to be_a(String)
+      expect(daily[0][:icon]).to be_a(String)
+      expect(daily[0]).to_not have_key(:maxtemp_c)
+      expect(daily[0]).to_not have_key(:mintemp_c)
+      expect(daily[0]).to_not have_key(:avgtemp_c)
+      expect(daily[0]).to_not have_key(:maxwind_kph)
+      expect(daily[0]).to_not have_key(:totalprecip_mm)
+      expect(daily[0]).to_not have_key(:avgvis_km)
+
+      expect(hourly).to be_a(Array)
+      expect(hourly[0]).to be_a(Hash)
+      expect(hourly[0][:time]).to be_a(String)
+      expect(hourly[0][:temperature]).to be_a(Float)
+      expect(hourly[0][:condition]).to be_a(String)
+      expect(hourly[0][:icon]).to be_a(String)
+      expect(hourly[0]).to_not have_key(:temp_c)
+      expect(hourly[0]).to_not have_key(:wind_kph)
+      expect(hourly[0]).to_not have_key(:wind_dir)
+      expect(hourly[0]).to_not have_key(:wind_degree)
+      expect(hourly[0]).to_not have_key(:pressure_mb)
+      expect(hourly[0]).to_not have_key(:pressure_in)
+    end
+  end
+end

--- a/spec/services/forecast_service_spec.rb
+++ b/spec/services/forecast_service_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe ForecastService do
+  describe 'class methods' do
+    it 'returns lat and long for a given location' do
+      lat_long = ForecastService.get_lat_long('Cincinatti, OH')
+      expect(lat_long).to be_a(String)
+      expect(ForecastService.get_lat_long('Cincinatti, OH')).to eq('39.10713,-84.50413')
+      expect(ForecastService.get_lat_long('Denver, CO')).to eq('39.74001,-104.99202')
+      expect(ForecastService.get_lat_long('San Diego, CA')).to eq('32.71568,-117.16171')
+    end
+
+    it 'returns forecast for a given location' do
+      weather = ForecastService.get_forecast('Cincinatti, OH')
+      current = weather[:current]
+      forecast = weather[:forecast]
+      hourly = forecast[:forecastday][0][:hour]
+      
+      expect(current).to be_a(Hash)
+      expect(current[:last_updated]).to be_a(String)
+      expect(current[:temp_f]).to be_a(Float)
+      expect(current[:feelslike_f]).to be_a(Float)
+      expect(current[:humidity]).to be_a(Integer)
+      expect(current[:uv]).to be_a(Float)
+      expect(current[:vis_miles]).to be_a(Float)
+      expect(current[:condition]).to be_a(Hash)
+      expect(current[:condition][:text]).to be_a(String)
+
+      expect(forecast).to be_a(Hash)
+      expect(forecast[:forecastday]).to be_an(Array)
+      expect(forecast[:forecastday].count).to eq(5)
+      expect(forecast[:forecastday][0]).to be_a(Hash)
+      expect(forecast[:forecastday][0][:date]).to be_a(String)
+      expect(forecast[:forecastday][0][:astro]).to be_a(Hash)
+      expect(forecast[:forecastday][0][:astro][:sunrise]).to be_a(String)
+      expect(forecast[:forecastday][0][:astro][:sunset]).to be_a(String)
+      expect(forecast[:forecastday][0][:day][:maxtemp_f]).to be_a(Float)
+      expect(forecast[:forecastday][0][:day][:mintemp_f]).to be_a(Float)
+      expect(forecast[:forecastday][0][:day][:condition][:text]).to be_a(String)
+      expect(forecast[:forecastday][0][:day][:condition][:icon]).to be_a(String)
+
+      expect(hourly).to be_an(Array)
+      expect(hourly.count).to eq(24)
+      expect(hourly[0][:time]).to be_a(String)
+      expect(hourly[0][:temp_f]).to be_a(Float)
+      expect(hourly[0][:condition]).to be_a(Hash)
+      expect(hourly[0][:condition][:text]).to be_a(String)
+      expect(hourly[0][:condition][:icon]).to be_a(String)
+    end
+  end
+end


### PR DESCRIPTION
Forecast service first takes the location params passed to controller and gets lat + lon, then uses that to get forecast for that specific area. Serializer hand rolled to match user story layout, cutting out unnecessary data and only providing what's asked.